### PR TITLE
Remove DiffusionConstantSource from nightly build

### DIFF
--- a/ClassicalField/Diffusion/DiffusionConstantSource/nightlytest.prop
+++ b/ClassicalField/Diffusion/DiffusionConstantSource/nightlytest.prop
@@ -1,1 +1,0 @@
-TestingPoint.0=.,-,expected_files,.,1e-7


### PR DESCRIPTION
Remove DiffusionConstantSource from nightly build since it is no longer maintained. No relevant tracker item.
