### PR TITLE
Update large uniaxial extension example

### DIFF
--- a/FiniteElasticity/LargeUniAxialExtension/.gitignore
+++ b/FiniteElasticity/LargeUniAxialExtension/.gitignore
@@ -1,0 +1,1 @@
+LargeUniaxialExtension.part*.ex*


### PR DESCRIPTION
Allow cubic Hermite interpolation, disabled by default so expected results are still the same.

I wanted to test an example with multiple cubic Hermite elements as the cantilever example doesn't work. This example does work though so it's probably a problem with RHS calculation when using gravity loading with cubic Hermite elements.
