### PR TITLE
Small example fixes

### DIFF
--- a/FiniteElasticity/CylinderInflation/nightlytest.json
+++ b/FiniteElasticity/CylinderInflation/nightlytest.json
@@ -3,5 +3,7 @@
     {
      "id": 1,
      "args": "-",
-     "expectedPath": "expected_results/1proc"}]
+     "tolerance": 1.0e-6,
+     "expectedPath": "expected_results/1proc",
+     "outputPath": "outputs"}]
 }}

--- a/FluidMechanics/NavierStokes/Static_FieldML/src/Static_FieldMLExample.f90
+++ b/FluidMechanics/NavierStokes/Static_FieldML/src/Static_FieldMLExample.f90
@@ -368,7 +368,7 @@ PROGRAM NAVIERSTOKESSTATICEXAMPLE
     & CMISSFieldUVariableType, "test_mesh.coordinates", err )
   CALL CMISSFieldCreateFinish( RegionUserNumber, GeometricFieldUserNumber, err )
 
-  CALL CMISSFieldMLInputFieldNodalParametersUpdate( fieldmlInfo, GeometricField, "test_mesh.node.coordinates", &
+  CALL CMISSFieldMLInputFieldParametersUpdate( fieldmlInfo, GeometricField, "test_mesh.node.coordinates", &
     & CMISSFieldUVariableType, CMISSFieldValuesSetType, err )
   CALL CMISSFieldParameterSetUpdateStart( GeometricField, CMISSFieldUVariableType, CMISSFieldValuesSetType, err )
   CALL CMISSFieldParameterSetUpdateFinish( GeometricField, CMISSFieldUVariableType, CMISSFieldValuesSetType, err )


### PR DESCRIPTION
Fix some failing examples.

Update changed FieldML routine and set output directory for cylinder inflation example.
