### PR TITLE
Update the LoadLever Job Description File according to recent change

### DIFF
--- a/scripts/nesi.template
+++ b/scripts/nesi.template
@@ -13,5 +13,7 @@
 #@ output = $(job_name).$(jobid).out
 #@ error = $(job_name).$(jobid).out
 #@ queue
- 
+
+ulimit -m 1048576 -v 1048576
+
 mpirun  {{test.command}}


### PR DESCRIPTION
Updating the LoadLever job description file since ulimit became mandatory. Simple change, no relevant tracker item.
