### PR TITLE
Changes for Finite Elasticity and Generalised Laplace to use metrices an...

### DIFF
--- a/FiniteElasticity/QuadraticEllipsoid/src/QuadraticEllipsoidExample.f90
+++ b/FiniteElasticity/QuadraticEllipsoid/src/QuadraticEllipsoidExample.f90
@@ -379,7 +379,7 @@ PROGRAM QUADRATICELLIPSOIDEEXAMPLE
   !Create the dependent field with 2 variables and 4 components (3 displacement, 1 pressure)
   CALL CMISSField_Initialise(DependentField,Err)
   CALL CMISSField_CreateStart(FieldDependentUserNumber,Region,DependentField,Err)
-  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GENERAL_TYPE,Err)
+  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GEOMETRIC_GENERAL_TYPE,Err)
   CALL CMISSField_MeshDecompositionSet(DependentField,Decomposition,Err)
   CALL CMISSField_GeometricFieldSet(DependentField,GeometricField,Err)
   CALL CMISSField_DependentTypeSet(DependentField,CMISS_FIELD_DEPENDENT_TYPE,Err)

--- a/FiniteElasticity/QuadraticEllipsoidCosta/src/QuadraticEllipsoidCostaExample.f90
+++ b/FiniteElasticity/QuadraticEllipsoidCosta/src/QuadraticEllipsoidCostaExample.f90
@@ -429,7 +429,7 @@ PROGRAM QUADRATICELLIPSOIDCOSTAEXAMPLE
   !Create the dependent field with 2 variables and 4 components (3 displacement, 1 pressure)
   CALL CMISSField_Initialise(DependentField,Err)
   CALL CMISSField_CreateStart(FieldDependentUserNumber,Region,DependentField,Err)
-  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GENERAL_TYPE,Err)
+  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GEOMETRIC_GENERAL_TYPE,Err)
   CALL CMISSField_MeshDecompositionSet(DependentField,Decomposition,Err)
   CALL CMISSField_GeometricFieldSet(DependentField,GeometricField,Err)
   CALL CMISSField_DependentTypeSet(DependentField,CMISS_FIELD_DEPENDENT_TYPE,Err)

--- a/FiniteElasticity/QuadraticEllipsoidCostaReadIn/src/QuadraticEllipsoidCostaReadInExample.f90
+++ b/FiniteElasticity/QuadraticEllipsoidCostaReadIn/src/QuadraticEllipsoidCostaReadInExample.f90
@@ -463,7 +463,7 @@ PROGRAM QUADRATICELLIPSOIDCOSTAREADINEXAMPLE
   !Create the dependent field with 2 variables and 4 components (3 displacement, 1 pressure)
   CALL CMISSField_Initialise(DependentField,Err)
   CALL CMISSField_CreateStart(FieldDependentUserNumber,Region,DependentField,Err)
-  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GENERAL_TYPE,Err)
+  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GEOMETRIC_GENERAL_TYPE,Err)
   CALL CMISSField_MeshDecompositionSet(DependentField,Decomposition,Err)
   CALL CMISSField_GeometricFieldSet(DependentField,GeometricField,Err)
   CALL CMISSField_DependentTypeSet(DependentField,CMISS_FIELD_DEPENDENT_TYPE,Err)

--- a/FiniteElasticity/TriQuadraticCube/src/TriQuadraticCubeExample.f90
+++ b/FiniteElasticity/TriQuadraticCube/src/TriQuadraticCubeExample.f90
@@ -312,7 +312,7 @@ PROGRAM TRIQUADRATICCUBEEXAMPLE
   !Create the dependent field with 2 variables and 4 components (3 displacement, 1 pressure)
   CALL CMISSField_Initialise(DependentField,Err)
   CALL CMISSField_CreateStart(FieldDependentUserNumber,Region,DependentField,Err)
-  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GENERAL_TYPE,Err)
+  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GEOMETRIC_GENERAL_TYPE,Err)
   CALL CMISSField_MeshDecompositionSet(DependentField,Decomposition,Err)
   CALL CMISSField_GeometricFieldSet(DependentField,GeometricField,Err)
   CALL CMISSField_DependentTypeSet(DependentField,CMISS_FIELD_DEPENDENT_TYPE,Err)

--- a/FiniteElasticity/UniAxialExtensionCompressible/src/UniAxialExtensionCompressibleExample.f90
+++ b/FiniteElasticity/UniAxialExtensionCompressible/src/UniAxialExtensionCompressibleExample.f90
@@ -328,7 +328,7 @@ PROGRAM UNIAXIALEXTENSIONEXAMPLE
   !Create a dependent field with two variables and four components
   CALL CMISSField_Initialise(DependentField,Err)
   CALL CMISSField_CreateStart(FieldDependentUserNumber,Region,DependentField,Err)
-  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GENERAL_TYPE,Err)  
+  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GEOMETRIC_GENERAL_TYPE,Err)  
   CALL CMISSField_MeshDecompositionSet(DependentField,Decomposition,Err)
   CALL CMISSField_GeometricFieldSet(DependentField,GeometricField,Err) 
   CALL CMISSField_DependentTypeSet(DependentField,CMISS_FIELD_DEPENDENT_TYPE,Err) 

--- a/FiniteElasticity/UniAxialExtensionLoadIncrements/src/UniAxialExtensionLoadIncrementsExample.f90
+++ b/FiniteElasticity/UniAxialExtensionLoadIncrements/src/UniAxialExtensionLoadIncrementsExample.f90
@@ -326,7 +326,7 @@ PROGRAM UNIAXIALEXTENSIONLOADINCREMENTSEXAMPLE
   !Create a dependent field with two variables and four components
   CALL CMISSField_Initialise(DependentField,Err)
   CALL CMISSField_CreateStart(FieldDependentUserNumber,Region,DependentField,Err)
-  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GENERAL_TYPE,Err)  
+  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GEOMETRIC_GENERAL_TYPE,Err)  
   CALL CMISSField_MeshDecompositionSet(DependentField,Decomposition,Err)
   CALL CMISSField_GeometricFieldSet(DependentField,GeometricField,Err) 
   CALL CMISSField_DependentTypeSet(DependentField,CMISS_FIELD_DEPENDENT_TYPE,Err) 

--- a/FiniteElasticity/UniAxialExtensionOrthotropic/src/UniAxialExtensionOrthotropicExample.f90
+++ b/FiniteElasticity/UniAxialExtensionOrthotropic/src/UniAxialExtensionOrthotropicExample.f90
@@ -519,7 +519,7 @@ PROGRAM UNIAXIALEXTENSIONORTHOTROPICEXAMPLE
   !Create a dependent field with two variables (displacement U, pressure P) and four components (u_x, u_y, u_z, p)
   CALL CMISSField_Initialise(DependentField,Err)
   CALL CMISSField_CreateStart(FieldDependentUserNumber,Region,DependentField,Err)
-  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GENERAL_TYPE,Err)  
+  CALL CMISSField_TypeSet(DependentField,CMISS_FIELD_GEOMETRIC_GENERAL_TYPE,Err)  
   CALL CMISSField_MeshDecompositionSet(DependentField,Decomposition,Err)
   CALL CMISSField_GeometricFieldSet(DependentField,GeometricField,Err) 
   CALL CMISSField_DependentTypeSet(DependentField,CMISS_FIELD_DEPENDENT_TYPE,Err) 


### PR DESCRIPTION
...d material systems.

Tidy up the generalised Laplace code and finite elasticity code to use interpolated points, metrics etc. etc. 
Finite elasticity dependent fields now need to be of geometric general type. 
